### PR TITLE
Use Travis CI to run tests on all code changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ python:
 matrix:
     allow_failures:
         - python: nightly
-        - python: pypy
         - python: pypy3
 install:
     - pip install --upgrade pip
     - pip install -r requirements.txt
     - pip install flake8
-    - npm -v
-    - npm install npm@latest -g
-    - npm -v
-    - npm install -g solc
+    - # npm -v
+    - # npm install npm@latest -g
+    - # npm -v
+    - # npm install -g solc
+    - snap install solc  # Do we need 'sudo'?
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ before_script:
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-script:
-    - python -m test.test_GST1
-    - python -m test.test_GST2
-    - python -m test.test_rlp
+script: true
+    # - python -m test.test_GST1
+    # - python -m test.test_GST2
+    # - python -m test.test_rlp
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 group: travis_latest
+sudo: required
 language: python
 cache: pip
 python:
     - 3.6
     #- nightly
-    #- pypy
     #- pypy3
 matrix:
     allow_failures:
@@ -18,7 +18,9 @@ install:
     - # npm install npm@latest -g
     - # npm -v
     - # npm install -g solc
-    - snap install solc  # Do we need 'sudo'?
+    - sudo apt update
+    - sudo apt install snapd
+    - sudo snap install solc
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: travis_latest
 language: python
 cache: pip
 python:
@@ -11,8 +12,13 @@ matrix:
         - python: pypy
         - python: pypy3
 install:
+    - pip install --upgrade pip
     - pip install -r requirements.txt
-    - pip install flake8  # pytest  # add another testing frameworks later
+    - pip install flake8
+    - npm -v
+    - npm install npm@latest -g
+    - npm -v
+    - npm install -g solc
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
 cache: pip
 python:
-    #- 2.7
     - 3.6
     #- nightly
     #- pypy
     #- pypy3
 matrix:
     allow_failures:
-        - python: 3.6
         - python: nightly
         - python: pypy
         - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: 3.6
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - python -m test.test_GST1
+    - python -m test.test_GST2
+    - python -m test.test_rlp
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 cache: pip
 python:
-    - 2.7
+    #- 2.7
     - 3.6
     #- nightly
     #- pypy
@@ -20,10 +20,10 @@ before_script:
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-script: true
-    # - python -m test.test_GST1
-    # - python -m test.test_GST2
-    # - python -m test.test_rlp
+script:
+    - time python -m test.test_GST1
+    - time python -m test.test_GST2
+    - time python -m test.test_rlp
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Every time someone submits a pull request, Travis Continuous Integration service can run the tests on it before it is reviewed.  Travis is always free to opensource projects like this one but the owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch on to enable testing.