### PR TITLE
Inline makeChild in mint and unroll loop

### DIFF
--- a/contract/GST2_ETH.sol
+++ b/contract/GST2_ETH.sol
@@ -128,8 +128,8 @@ contract GasToken2 is Rlp {
             // Almost done! All we have to do is put this short (31 bytes) blob into
             // memory and call CREATE with the appropriate offsets.
             let solidity_free_mem_ptr := mload(0x40)
-            mstore(solidity_free_mem_ptr, 0x00756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af3)
-            addr := create(0, add(solidity_free_mem_ptr, 1), 31)
+            mstore(solidity_free_mem_ptr, 0x756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af300)
+            addr := create(0, solidity_free_mem_ptr, 31)
         }
     }
 

--- a/contract/GST2_ETH.sol
+++ b/contract/GST2_ETH.sol
@@ -139,7 +139,25 @@ contract GasToken2 is Rlp {
     function mint(uint256 value) public {
         assembly {
             mstore(0, 0x756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af300)
-            for {let i := value} i {i := sub(i, 1)} {
+            for {let i := shr(value, 5)} i {i := sub(i, 1)} {
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+                pop(create(0, 0, 31)) pop(create(0, 0, 31))
+            }
+            for {let i := and(value, 0x1F)} i {i := sub(i, 1)} {
                 pop(create(0, 0, 31))
             }
         }

--- a/contract/GST2_ETH.sol
+++ b/contract/GST2_ETH.sol
@@ -127,9 +127,9 @@ contract GasToken2 is Rlp {
             // Or in binary: 756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af3
             // Almost done! All we have to do is put this short (31 bytes) blob into
             // memory and call CREATE with the appropriate offsets.
-            let solidity_free_mem_ptr := mload(0x40)
-            mstore(solidity_free_mem_ptr, 0x756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af300)
-            addr := create(0, solidity_free_mem_ptr, 31)
+            // We can use Solidity's scratch space located at [0..64).
+            mstore(0, 0x756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af300)
+            addr := create(0, 0, 31)
         }
     }
 

--- a/contract/GST2_ETH.sol
+++ b/contract/GST2_ETH.sol
@@ -137,8 +137,11 @@ contract GasToken2 is Rlp {
     // new child contracts. The minted tokens are owned by the caller of this
     // function.
     function mint(uint256 value) public {
-        for (uint256 i = 0; i < value; i++) {
-            makeChild();
+        assembly {
+            mstore(0, 0x756eb3f879cb30fe243b4dfee438691c043318585733ff6000526016600af300)
+            for {let i := value} i {i := sub(i, 1)} {
+                pop(create(0, 0, 31))
+            }
         }
         s_head += value;
         s_balances[msg.sender] += value;


### PR DESCRIPTION
Continues from PR #7. I think the mint function has no further optimizations that are O(value), unless Solidity does some sub-optimal stack management.

There's another O(value) optimization possible with the trick in #6.